### PR TITLE
Fix dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This helps debug your tagging implementation.
 
 ```groovy
 dependencies {
-  debugImplementation 'com.adevinta.android:taggingviewer:+'
-  releaseImplementation 'com.adevinta.android:taggingviewer-no-op:+'
+  debugImplementation 'com.adevinta.android:tagging-viewer:+'
+  releaseImplementation 'com.adevinta.android:tagging-viewer-no-op:+'
 }
 ```
 (Check for latest version in GitHub releases)


### PR DESCRIPTION
The dependency on the readme was not working. After a quick search on mavencentral, I realised the module name contains a typo.

https://search.maven.org/search?q=g:com.adevinta.android