### PR TITLE
Add fake secrets for local development

### DIFF
--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -1,3 +1,11 @@
+// Create variables with empty default values
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+ext["signing.keyId"] = '0C762F0D'
+ext["signing.password"] = 'dsLCfZhaoHbgqgNeRHuAY'
+ext["signing.secretKeyRingFile"] = '../secret.gpg'
+
 File secretPropsFile = project.rootProject.file('local.properties')
 if (secretPropsFile.exists()) {
     // Read local.properties file first if it exists


### PR DESCRIPTION
I'm adding fake publication secrets (see https://github.com/AdevintaSpain/Barista/pull/471) to allow local development for external contributors. The values are copied from https://github.com/AdevintaSpain/Barista, let me know if I should use different ones