### PR TITLE
Fix codestyle script

### DIFF
--- a/config/androidstudio/install-codestyle.sh
+++ b/config/androidstudio/install-codestyle.sh
@@ -15,11 +15,9 @@ for i in $HOME/Library/Preferences/IntelliJIdea*  \
          $HOME/Library/Application\ Support/Google/AndroidStudio* \
          $HOME/Library/Application\ Support/JetBrains/IdeaIC*
 do
-  if [[ -d $i ]]; then
-    # create codestyle folders
-    mkdir -p $i/codestyles
-    # copy xmls
-    cp -frv "$CONFIGS/codestyle"/* $i/codestyles
+  if [[ -d "$i" ]]; then
+    mkdir -p "$i/codestyles"
+    cp -frv "$CONFIGS/codestyle"/* "$i/codestyles"
   fi
 done
 


### PR DESCRIPTION
The current script failed to install the code style. Because of the newer folders with spaces in their name (Application\ Support), the script was creating a new directory called "Support" in the root of the project.

I guess this must be happening since some MacOS version or something. But I fixed it based on this commit from the original repository: https://github.com/square/java-code-styles/commit/edfc51e801bf538d661be5484be684bbc3a786df