### PR TITLE
Fix overlay alignment

### DIFF
--- a/taggingviewer/src/main/java/com/adevinta/android/taggingviewer/internal/view/TagEntryItemViewHolder.kt
+++ b/taggingviewer/src/main/java/com/adevinta/android/taggingviewer/internal/view/TagEntryItemViewHolder.kt
@@ -26,7 +26,7 @@ internal class TagEntryItemViewHolder(binding: TaggingViewItemBinding) : ViewHol
   companion object {
     fun build(parent: ViewGroup): TagEntryItemViewHolder {
       val inflater = LayoutInflater.from(parent.context)
-      val binding = TaggingViewItemBinding.inflate(inflater)
+      val binding = TaggingViewItemBinding.inflate(inflater, parent, false)
       return TagEntryItemViewHolder(binding)
     }
   }

--- a/taggingviewer/src/main/res/layout/tagging_view_item.xml
+++ b/taggingviewer/src/main/res/layout/tagging_view_item.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             xmlns:tools="http://schemas.android.com/tools"
-             android:layout_width="match_parent"
-             android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="right"
     >
 
   <LinearLayout

--- a/taggingviewer/src/main/res/layout/tagging_view_wrapper.xml
+++ b/taggingviewer/src/main/res/layout/tagging_view_wrapper.xml
@@ -23,7 +23,6 @@
     <com.adevinta.android.taggingviewer.internal.view.TaggingOverlayListView
         android:id="@+id/tagging_viewer_tags_list"
         android:layout_width="match_parent"
-        android:layout_gravity="end"
         android:layout_height="wrap_content"
         android:paddingBottom="8dp"
         android:paddingTop="8dp"


### PR DESCRIPTION
Originally, this library used to show the overlay items aligned to the right. That's why the icons are on the right side of the list. This behaviour was accidentally broken on some internal refactor previous to publishing the library.

I found the bug and fixed it. It was caused by the missing `parent` parameter in the ViewHolder inflation.

Before | After
---|---
<img width="280" src="https://user-images.githubusercontent.com/545251/205338265-3843ba63-08f2-4e06-839f-ea3dc03dce07.png" /> | <img width="280" src="https://user-images.githubusercontent.com/545251/205338405-a2cbaf1b-7d0c-4980-81f9-11ae05ea986d.png" />


