### PR TITLE
Fix overflowing items icon

### DIFF
--- a/taggingviewer/src/main/res/layout/tagging_view_item.xml
+++ b/taggingviewer/src/main/res/layout/tagging_view_item.xml
@@ -18,12 +18,13 @@
     <TextView
         android:id="@+id/tracking_name"
         style="@style/tgv_item_tracking_name"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="end|center_vertical"
         android:ellipsize="end"
         android:includeFontPadding="false"
         android:lines="1"
+        android:layout_weight="1"
         android:paddingStart="8dp"
         tools:text="Some Event Name"
         />


### PR DESCRIPTION
When an item in the overlay is too long and overflows, the icon is thrown out of the screen. With this small fix, the icon will always be visible, even if the text needs to ellipsize. 

Before | After
---|---
<img width="280" src="https://user-images.githubusercontent.com/545251/205339146-5ecf981e-0e98-4a68-946e-cd18827dbcb8.png" /> | <img width="280" src="https://user-images.githubusercontent.com/545251/205339228-8d8c4198-f388-4d1f-b978-00595edd898a.png" />



