### PR TITLE
Fix library authority name used at TaggingViewerInitProvider

### DIFF
--- a/taggingviewer/src/main/java/com/adevinta/android/taggingviewer/internal/TaggingViewerInitProvider.kt
+++ b/taggingviewer/src/main/java/com/adevinta/android/taggingviewer/internal/TaggingViewerInitProvider.kt
@@ -24,7 +24,7 @@ class TaggingViewerInitProvider : ContentProvider() {
       throw NullPointerException("YourLibraryInitProvider ProviderInfo cannot be null.")
     }
     // So if the authorities equal the library internal ones, the developer forgot to set his applicationId
-    if (BuildConfig.LIBRARY_PACKAGE_NAME + ".yourlibraryinitprovider" == providerInfo.authority) {
+    if (BuildConfig.LIBRARY_PACKAGE_NAME + ".taggingviewerinitprovider" == providerInfo.authority) {
       throw IllegalStateException(
         "Incorrect provider authority in manifest. Most likely due to a " + "missing applicationId variable in application\'s build.gradle."
       )


### PR DESCRIPTION
Change the authority name used to check if the client application has set the applicationId.

The authority should be checked against the library one, which is defined at the `AndroidManifest.xml` file and is like this:

`android:authorities="${applicationId}.taggingviewerinitprovider"`

So the name used at the `attachInfo()` function should be the same `taggingviewerinitprovider` instead of `yourlibraryinitprovider`