### PR TITLE
Avoid context parameter to enable Overlay

### DIFF
--- a/sample/src/main/java/com/adevinta/android/taggingviewer/sample/ListActivity.kt
+++ b/sample/src/main/java/com/adevinta/android/taggingviewer/sample/ListActivity.kt
@@ -24,7 +24,7 @@ class ListActivity : AppCompatActivity() {
       switch.isChecked = TaggingViewer.isOverlayEnabled()
       switch.setOnCheckedChangeListener { _, isChecked ->
         if (isChecked) {
-          TaggingViewer.enableOverlay(this)
+          TaggingViewer.enableOverlay()
         } else {
           TaggingViewer.disableOverlay()
         }

--- a/sample/src/main/java/com/adevinta/android/taggingviewer/sample/MainSampleActivity.kt
+++ b/sample/src/main/java/com/adevinta/android/taggingviewer/sample/MainSampleActivity.kt
@@ -16,7 +16,7 @@ class MainSampleActivity : AppCompatActivity() {
 
     findViewById<SwitchCompat>(R.id.overlayEnabledSwitch).setOnCheckedChangeListener { _, isChecked ->
       if (isChecked) {
-        TaggingViewer.enableOverlay(this)
+        TaggingViewer.enableOverlay()
       } else {
         TaggingViewer.disableOverlay()
       }

--- a/sample/src/main/java/com/adevinta/android/taggingviewer/sample/MergeActivity.kt
+++ b/sample/src/main/java/com/adevinta/android/taggingviewer/sample/MergeActivity.kt
@@ -16,7 +16,7 @@ class MergeActivity : AppCompatActivity() {
       switch.isChecked = TaggingViewer.isOverlayEnabled()
       switch.setOnCheckedChangeListener { _, isChecked ->
         if (isChecked) {
-          TaggingViewer.enableOverlay(this)
+          TaggingViewer.enableOverlay()
         } else {
           TaggingViewer.disableOverlay()
         }

--- a/taggingviewer/src/main/java/com/adevinta/android/taggingviewer/TaggingViewer.kt
+++ b/taggingviewer/src/main/java/com/adevinta/android/taggingviewer/TaggingViewer.kt
@@ -13,15 +13,18 @@ import com.adevinta.android.taggingviewer.internal.TaggingConfig
 import com.adevinta.android.taggingviewer.internal.TaggingViewerUiComponent
 import com.adevinta.android.taggingviewer.internal.TrackingDispatcher
 import com.adevinta.android.taggingviewer.internal.util.ActivityLifecycleCallbacksAdapter
+import java.lang.ref.WeakReference
 
 object TaggingViewer {
 
   internal var isOverlayEnabled: Boolean = false
   internal var isActivitySeparatorEnabled: Boolean = true
   internal var isActivityNameSeparatorEnabled: Boolean = false
+  internal var currentActivity: WeakReference<Activity>? = null
 
   private val activityLifecycleCallbacks = object : ActivityLifecycleCallbacksAdapter() {
     override fun onActivityStarted(activity: Activity) {
+      currentActivity = WeakReference(activity)
       if (isOverlayEnabled) {
         injectTaggingIntoActivity(activity)
       }
@@ -65,7 +68,7 @@ object TaggingViewer {
     ReplaceWith("enableOverlay(context)")
   )
   fun enable(context: Context) {
-    enableOverlay(context)
+    enableOverlay()
   }
 
   @JvmStatic
@@ -78,10 +81,10 @@ object TaggingViewer {
   fun isOverlayEnabled(): Boolean = isOverlayEnabled
 
   @JvmStatic
-  fun enableOverlay(context: Context) {
+  fun enableOverlay() {
     isOverlayEnabled = true
-    if (context is Activity) {
-      injectTaggingIntoActivity(context)
+    currentActivity?.get()?.let {
+      injectTaggingIntoActivity(it)
     }
     TrackingDispatcher.refreshScreen()
   }


### PR DESCRIPTION
`enableOverlay(context)` behaves erratically when passing different types of context. If the Context is an Activity, it enables the Overlay in the current screen. If it's other type (application, ContextThemeWrapper) it won't enable it on the current screen, but will enable it on the next screen you open. This is weird.

To make the API easier to use, I removed the `context` parameter from the `enableOverlay` function. Instead, I kept a WeakReference of the current Activity. Whenever the overlay is enabled, we inject the overlay on this activity (if exists). That way we can safely enable the overlay from anywhere.

⚠️ Breaking API change! (I guess it's no problem since 1.0.0 isn't released yet)